### PR TITLE
Stop recomposing QuotesListScreen twice

### DIFF
--- a/app/src/main/java/www/spikeysanju/jetquotes/navigation/NavGraph.kt
+++ b/app/src/main/java/www/spikeysanju/jetquotes/navigation/NavGraph.kt
@@ -61,9 +61,7 @@ fun NavGraph(toggleTheme: () -> Unit) {
     NavHost(navController, startDestination = Screen.Home.route) {
         // Quotes List
         composable(Screen.Home.route) {
-            val viewModel: MainViewModel = viewModel(
-                factory = HiltViewModelFactory(LocalContext.current, it)
-            )
+            val viewModel = hiltViewModel<MainViewModel>(it)
             QuotesListScreen(viewModel, toggleTheme, actions)
         }
 


### PR DESCRIPTION
- Fix the bug of QuotesListScreen recompose twice when we pressed back buttom from QuoteDetail View
- Due to this recomposition again and again the method inside the composable view is running twice which is a heavy operation for the memory