### PR TITLE
Disabled Forced Dark Theme Support

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -32,6 +32,9 @@
 
     <!-- Base application theme. -->
     <style name="Theme.JetQuotes" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Disable forced dark mode -->
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/defaultNight</item>
         <item name="colorPrimaryVariant">@color/defaultNightDark</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,6 +31,9 @@
 
     <!-- Base application theme. -->
     <style name="Theme.JetQuotes" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Disable forced dark mode -->
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/defaultDay</item>
         <item name="colorPrimaryVariant">@color/defaultDayDark</item>


### PR DESCRIPTION
## Changelogs :
1. Updated Style `theme.JetQuotes` to disable darkmodeAllowed flag to false

## How to Test?
@Spikeysanju  Tried forced dark theme from setting and developer option but was unable to produce image as shown in the Issue #122 

Please also refer to this section of Official [Channel Video - Dark Theme](https://youtu.be/f3ol75NTud0?t=206) and let me know if theme and colors could also be the issue

