### PR TITLE
Update CTAButtons.kt

### DIFF
--- a/app/src/main/java/www/spikeysanju/jetquotes/components/CTAButtons.kt
+++ b/app/src/main/java/www/spikeysanju/jetquotes/components/CTAButtons.kt
@@ -90,9 +90,13 @@ fun CTAButtons(viewModel: MainViewModel, quote: String, author: String) {
                 icon = painterResource(id = R.drawable.ic_share),
                 name = stringResource(R.string.text_share),
                 modifier = Modifier.clickable(onClick = {
-                    context.shareToOthers(quote.plus("").plus("- $author"))
-                })
-            )
+                    val sharedText = quote.plus("").plus("- $author")
+                    val appUrl = "https://yourappurl.com" // Replace this with your actual app URL
+                    val textWithUrl = "$sharedText\n$appUrl"
+                    context.shareToOthers(textWithUrl)
+    })
+)
+
 
             Spacer(modifier = Modifier.width(30.dp))
 


### PR DESCRIPTION
The previous share does not share quote to social network with the app url. So by editing this line of code, users will be able to share the quote along side the app download link from google playstore.